### PR TITLE
Fix camera view matrix translation and log diagnostics

### DIFF
--- a/engine/renderer/Private/Camera.cpp
+++ b/engine/renderer/Private/Camera.cpp
@@ -88,7 +88,7 @@ void Camera::RecalculateViewMatrix() {
     // World up
     Math::Vector3D worldUp = Math::Vector3D::UnitY();
 
-    // Right = normalize(cross(forward, worldUp))
+    // Right = normalize(cross(forward, worldUp)) following OpenGL's right-handed lookAt convention
     Math::Vector3D right = forward.cross(worldUp).normalized();
 
     // Recomputed up = cross(right, forward)
@@ -102,17 +102,17 @@ void Camera::RecalculateViewMatrix() {
     const Math::Vector3D &s = right;
     const Math::Vector3D &u = up;
 
-    // translation components
-    double tx = - (s.x() * position_.x() + s.y() * position_.y() + s.z() * position_.z());
-    double ty = - (u.x() * position_.x() + u.y() * position_.y() + u.z() * position_.z());
-    double tz =   (f.x() * position_.x() + f.y() * position_.y() + f.z() * position_.z());
+    const Math::Vector3D eye = position_;
+    const double tx = -s.dot(eye);
+    const double ty = -u.dot(eye);
+    const double tz = f.dot(eye);
 
     // Column-major layout: m[col*4 + row]
     std::array<double, 16> m{};
-    m[0]  = s.x(); m[1]  = s.y(); m[2]  = s.z(); m[3]  = tx;
-    m[4]  = u.x(); m[5]  = u.y(); m[6]  = u.z(); m[7]  = ty;
-    m[8]  = -f.x();m[9]  = -f.y();m[10] = -f.z();m[11] = tz;
-    m[12] = 0.0;   m[13] = 0.0;   m[14] = 0.0;   m[15] = 1.0;
+    m[0]  = s.x();  m[1]  = s.y();  m[2]  = s.z();  m[3]  = 0.0;
+    m[4]  = u.x();  m[5]  = u.y();  m[6]  = u.z();  m[7]  = 0.0;
+    m[8]  = -f.x(); m[9]  = -f.y(); m[10] = -f.z(); m[11] = 0.0;
+    m[12] = tx;     m[13] = ty;     m[14] = tz;     m[15] = 1.0;
 
     const_cast<Camera*>(this)->viewMatrix_ = m;
 }

--- a/engine/renderer/Private/Renderer.cpp
+++ b/engine/renderer/Private/Renderer.cpp
@@ -5,8 +5,12 @@
 #include <glad/glad.h>
 
 #include "Renderer.h"
-#include <iostream>
+#include <array>
+#include <cmath>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 // minimal point sprite shader sources - updated to use view/projection matrices
 static const char *ptsVs = R"glsl(
@@ -200,6 +204,39 @@ void Arche::Render::Renderer::render(std::vector<Arche::Scene::BodyView> const &
     // Convert camera matrices (double) to float arrays for GL
     auto viewD = mainViewportCamera->GetViewMatrix();
     auto projD = mainViewportCamera->GetProjectionMatrix();
+
+    static std::array<double, 16> lastLoggedView{};
+    static bool hasLoggedView = false;
+    bool shouldLogView = !hasLoggedView;
+    if (!shouldLogView) {
+        for (size_t i = 0; i < viewD.size(); ++i) {
+            if (std::abs(viewD[i] - lastLoggedView[i]) > 1e-6) {
+                shouldLogView = true;
+                break;
+            }
+        }
+    }
+
+    if (shouldLogView) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(4);
+        oss << "View matrix (column-major rows):";
+        for (int row = 0; row < 4; ++row) {
+            oss << "\n[";
+            for (int col = 0; col < 4; ++col) {
+                const int idx = col * 4 + row;
+                oss << viewD[idx];
+                if (col < 3) {
+                    oss << ", ";
+                }
+            }
+            oss << "]";
+        }
+        ARCHE_LOG_INFO(mLogger, oss.str());
+        lastLoggedView = viewD;
+        hasLoggedView = true;
+    }
+
     float viewF[16];
     float projF[16];
     for (int i = 0; i < 16; ++i) {


### PR DESCRIPTION
## Summary
- place the camera view matrix translation terms in the final column and compute them via dot products with the eye position
- retain the OpenGL look-at basis construction while adding logging that emits the view matrix whenever it changes

## Testing
- `cmake -S . -B build` *(fails: missing bundled GLFW sources and system OpenGL libraries in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144f3907988325bd279b713a63c879)