### PR TITLE
Add OpenGL shadow map resources and enable shadow pass

### DIFF
--- a/engine/renderer/Private/OpenGLBackend.cpp
+++ b/engine/renderer/Private/OpenGLBackend.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <iostream>
 #include <vector>
 
 #include "OpenGLBackend.h"
@@ -146,6 +147,8 @@ void OpenGLBackend::initialise() {
     // Create FBO and color/depth attachments
     initialiseFrameBuffer();
 
+    initialiseShadowResources(m_shadowMapResolution);
+
     // Default cached matrices: identity
     for (int i = 0; i < 16; ++i) {
         m_viewF[i] = (i % 5 == 0) ? 1.0f : 0.0f;
@@ -166,6 +169,16 @@ void OpenGLBackend::shutdown() noexcept {
     if (m_frameBuffer) {
         glDeleteFramebuffers(1, &m_frameBuffer);
         m_frameBuffer = 0;
+    }
+
+    if (m_shadowMapTexture) {
+        glDeleteTextures(1, &m_shadowMapTexture);
+        m_shadowMapTexture = 0;
+    }
+
+    if (m_shadowFrameBuffer) {
+        glDeleteFramebuffers(1, &m_shadowFrameBuffer);
+        m_shadowFrameBuffer = 0;
     }
 
     // Mesh resources
@@ -344,6 +357,9 @@ void OpenGLBackend::drawMesh(const Mesh &mesh, const glm::mat4 &model) {
 
 
 void OpenGLBackend::beginShadowPass() {
+    if (m_shadowFrameBuffer == 0)
+        return;
+
     glBindFramebuffer(GL_FRAMEBUFFER, m_shadowFrameBuffer);
     glViewport(0, 0, m_shadowMapResolution, m_shadowMapResolution);
     glClear(GL_DEPTH_BUFFER_BIT);
@@ -353,6 +369,49 @@ void OpenGLBackend::endShadowPass() {
     glBindFramebuffer(GL_FRAMEBUFFER, m_frameBuffer);
     glViewport(0, 0, m_Backbuffer.x, m_Backbuffer.y);
     glUseProgram(0);
+}
+
+void OpenGLBackend::initialiseShadowResources(int resolution) {
+    if (resolution <= 0)
+        resolution = 1024;
+
+    if (m_shadowMapTexture) {
+        glDeleteTextures(1, &m_shadowMapTexture);
+        m_shadowMapTexture = 0;
+    }
+
+    if (m_shadowFrameBuffer) {
+        glDeleteFramebuffers(1, &m_shadowFrameBuffer);
+        m_shadowFrameBuffer = 0;
+    }
+
+    m_shadowMapResolution = resolution;
+
+    glGenFramebuffers(1, &m_shadowFrameBuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_shadowFrameBuffer);
+
+    glGenTextures(1, &m_shadowMapTexture);
+    glBindTexture(GL_TEXTURE_2D, m_shadowMapTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32F, m_shadowMapResolution, m_shadowMapResolution, 0,
+                 GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    const float borderColor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_shadowMapTexture, 0);
+    glDrawBuffer(GL_NONE);
+    glReadBuffer(GL_NONE);
+
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        std::cerr << "[OpenGL] Shadow framebuffer incomplete: 0x" << std::hex << status << std::dec << "\n";
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 void OpenGLBackend::drawMeshDepthOnly(const Mesh &mesh, const glm::mat4 &model) {
@@ -447,6 +506,14 @@ void OpenGLBackend::setUniform1f(const std::string &name, float value) {
     GLint loc = getUniformLocation(*m_currentShader, name);
     if (loc >= 0)
         glUniform1f(loc, value);
+}
+
+void OpenGLBackend::setUniform1i(const std::string &name, int value) {
+    if (!m_currentShader || m_currentShader->programID == 0)
+        return;
+    GLint loc = getUniformLocation(*m_currentShader, name);
+    if (loc >= 0)
+        glUniform1i(loc, value);
 }
 
 void OpenGLBackend::setDepthMask(bool enabled) { glDepthMask(enabled ? GL_TRUE : GL_FALSE); }

--- a/engine/renderer/Private/ShadowPass.cpp
+++ b/engine/renderer/Private/ShadowPass.cpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 #include <memory>
 
 #include "Camera.h"
@@ -15,12 +16,25 @@
 namespace Arche::Render {
 
     void Arche::Render::ShadowPass::initialise(IRenderBackend &backend) {
-        //backend.initialiseShadowResources(m_resolution);
+        backend.initialiseShadowResources(m_resolution);
         m_shadowMapID = backend.getShadowMapTextureID();
+        m_initialised = m_shadowMapID != 0;
     }
 
     void Arche::Render::ShadowPass::render(const RenderView &view, IRenderBackend &backend, const Camera &camera,
                                            ResourceRegistry &resources, RenderPassSettings &settings) {
+        settings.shadowSettings.enabled = false;
+        settings.shadowSettings.shadowMapID = 0;
+        settings.shadowSettings.resolution = 0;
+        settings.shadowSettings.lightSpaceMatrix = glm::mat4(1.0f);
+
+        if (!m_initialised)
+            return;
+
+        auto depthShader = resources.getShader("ShadowDepth");
+        if (!depthShader)
+            return;
+
         glm::vec3 lightDir = glm::normalize(settings.globalSettings.directionalLightDirection);
 
         glm::vec3 lightPos = -lightDir * settings.globalSettings.directionalLightDistance;
@@ -32,13 +46,12 @@ namespace Arche::Render {
         m_lightSpaceMatrix = lightProj * lightView;
 
         backend.beginShadowPass();
+        backend.setShader(depthShader);
+        backend.setUniformMat4("uLightSpaceMatrix", m_lightSpaceMatrix);
 
         for (const auto &entity : view.opaqueObjects) {
             if (!entity)
                 continue;
-
-            auto depthShader = resources.getShader("ShadowDepth");
-            backend.setShader(depthShader);
 
             glm::mat4 model{glm::translate(glm::mat4(1.0f), entity->getPosition())};
             model = glm::scale(model, entity->getScale());
@@ -49,17 +62,22 @@ namespace Arche::Render {
                 continue;
             }
 
-            backend.setUniformMat4("uLightSpaceMatrix", m_lightSpaceMatrix);
             backend.setUniformMat4("uModel", model);
 
             backend.drawMeshDepthOnly(*mesh, model);
         }
 
+        backend.endShadowPass();
+
+        m_shadowMapID = backend.getShadowMapTextureID();
+        m_initialised = m_shadowMapID != 0;
+
+        if (!m_initialised)
+            return;
+
         settings.shadowSettings.shadowMapID = m_shadowMapID;
         settings.shadowSettings.lightSpaceMatrix = m_lightSpaceMatrix;
         settings.shadowSettings.resolution = m_resolution;
         settings.shadowSettings.enabled = true;
-
-        backend.endShadowPass();
     }
 } // namespace Arche::Render

--- a/engine/renderer/Public/GeometryPass.h
+++ b/engine/renderer/Public/GeometryPass.h
@@ -68,6 +68,8 @@ namespace Arche {
                 backend.setUniformVec3("uLightColor", settings.globalSettings.directionalLightColor); // unit intensity
 
                 // Shadows
+                backend.setUniform1i("uHasShadowMap", settings.shadowSettings.enabled ? 1 : 0);
+
                 if (settings.shadowSettings.enabled) {
                     backend.setUniformMat4("uLightSpaceMatrix", settings.shadowSettings.lightSpaceMatrix);
                     // Bind depth texture to a stable unit; the backend should set uShadowMap to this unit internally.

--- a/engine/renderer/Public/IRenderBackend.h
+++ b/engine/renderer/Public/IRenderBackend.h
@@ -35,10 +35,13 @@ namespace Arche {
             virtual void setUniformMat4(const std::string &name, const glm::mat4 &value) = 0;
             virtual void setUniformVec4(const std::string &name, const glm::vec4 &value) = 0;
             virtual void setUniform1f(const std::string &name, float value) = 0;
+            virtual void setUniform1i(const std::string &name, int value) = 0;
             virtual void setUniformVec3(const std::string &name, const glm::vec3 &value) = 0;
             virtual unsigned int getRenderTextureID() const = 0;
 
             virtual void bindTexture(const std::string &name, unsigned int textureID, int slot) = 0;
+
+            virtual void initialiseShadowResources(int resolution) = 0;
 
             virtual void beginShadowPass() = 0;
             virtual void endShadowPass() = 0;

--- a/engine/renderer/Public/OpenGLBackend.h
+++ b/engine/renderer/Public/OpenGLBackend.h
@@ -55,6 +55,7 @@ namespace Arche {
             unsigned int getRenderTextureID() const override { return m_colorTexture; }
             void bindTexture(const std::string &name, unsigned int textureID, int slot) override;
 
+            void initialiseShadowResources(int resolution) override;
             void beginShadowPass() override;
             void endShadowPass() override;
             unsigned int getShadowMapTextureID() const override { return m_shadowMapTexture; }
@@ -63,6 +64,7 @@ namespace Arche {
             void setUniformMat4(const std::string &name, const glm::mat4 &value) override;
             void setUniformVec4(const std::string &name, const glm::vec4 &value) override;
             void setUniform1f(const std::string &name, float value) override;
+            void setUniform1i(const std::string &name, int value) override;
             void setUniformVec3(const std::string &name, const glm::vec3 &value) override;
             void setDepthMask(bool enabled) override;
             void setWireframe(bool enabled) override;


### PR DESCRIPTION
## Summary
- create and manage dedicated OpenGL framebuffer resources for shadow maps and expose initialisation and integer uniform helpers through the render backend
- update the shadow render pass to generate the light-space depth map once per frame and provide the data to later passes
- ensure the geometry pass binds the shadow map and toggles lighting uniforms so surface shaders can sample the generated shadows

## Testing
- cmake -S . -B build *(fails: missing GLFW submodule and OpenGL headers in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917994c3a1c8325bb2ce707a25bf445)