### PR TITLE
Implement comprehensive entity inspector panel

### DIFF
--- a/app/modules/entity-inspector/Private/EntityInspector.cpp
+++ b/app/modules/entity-inspector/Private/EntityInspector.cpp
@@ -4,65 +4,253 @@
 
 #include "EntityInspector.h"
 
+#include <Material.h>
+#include <RenderingSystem.h>
+#include <ResourceRegistry.h>
+#include <RigidBody.h>
 #include <WorldSystem.h>
 #include <imgui.h>
 
-#include <algorithm> // for std::max, std::min
-#include <array>
-#include <chrono>
+#include <algorithm>
 #include <glm/gtc/type_ptr.hpp>
-#include <iostream>
-#include <numeric>
-#include <vector>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace Arche {
     namespace GUI {
 
         void EntityInspector::Draw() {
-            ImGui::Begin(name.c_str(), nullptr, ImGuiWindowFlags_None);
+            if (!ImGui::Begin(name.c_str(), nullptr, ImGuiWindowFlags_None)) {
+                ImGui::End();
+                return;
+            }
 
-            ImGui::Text("Entity Inspector Panel");
-        
-            if (context->getSelectedEntity())
-            {
-                ImGui::Text("Selected Entity ID: %llu", context->getSelectedEntity().value());
+            auto entity = resolveSelectedEntity();
+            if (!entity) {
+                ImGui::TextUnformatted("No entity selected.");
+                ImGui::End();
+                return;
+            }
 
-                // Find element in world system
-                auto worldSystem = context->worldSystem();
-                auto view = worldSystem->view();
-                auto it = std::find_if(view.bodies.begin(), view.bodies.end(),
-                                       [selectedID = context->getSelectedEntity().value()](const std::shared_ptr<Scene::IEntity>& entity) {
-                                           return entity->getID() == selectedID;
-                    });
+            ImGui::Text("Entity: %s", std::string(entity->getName()).c_str());
+            ImGui::Text("ID: %llu", static_cast<unsigned long long>(entity->getID()));
+            ImGui::Separator();
 
-                if (it != view.bodies.end())
-                    {auto entity = *it;
-                    glm::vec3 position = entity->getPosition();
-                    glm::vec3 rotation = entity->getRotation();
-                    glm::vec3 scale = entity->getScale();
-                    ImGui::Text("Name: %s", std::string(entity->getName()).c_str());
-                    ImGui::Text("Mesh ID: %s", std::string(entity->getMeshId()).c_str());
-                    ImGui::Text("Material ID: %s", std::string(entity->getMaterialId()).c_str());
-                    ImGui::Text("Shader ID: %s", std::string(entity->getShaderId()).c_str());
-                    ImGui::Separator();
-                    ImGui::Text("Transform:");
-                    ImGui::InputFloat3("Position", glm::value_ptr(position));
-                    ImGui::InputFloat3("Rotation", glm::value_ptr(rotation));
-                    ImGui::InputFloat3("Scale", glm::value_ptr(scale));
-                    // Update entity transform if changed
-                    if (ImGui::Button("Apply Transform"))
-                    {
-                        entity->setPosition(position);
-                        entity->setRotation(rotation);
-                        entity->setScale(scale);
-                    }
+            if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
+                glm::vec3 position = entity->getPosition();
+                if (ImGui::DragFloat3("Position", glm::value_ptr(position), 0.05f)) {
+                    entity->setPosition(position);
                 }
-                else
-                {
-                    ImGui::Text("Selected entity not found in world.");
+
+                glm::vec3 rotation = entity->getRotation();
+                if (ImGui::DragFloat3("Rotation", glm::value_ptr(rotation), 0.5f)) {
+                    entity->setRotation(rotation);
+                }
+
+                glm::vec3 scale = entity->getScale();
+                if (ImGui::DragFloat3("Scale", glm::value_ptr(scale), 0.05f, 0.001f)) {
+                    scale.x = std::max(scale.x, 0.001f);
+                    scale.y = std::max(scale.y, 0.001f);
+                    scale.z = std::max(scale.z, 0.001f);
+                    entity->setScale(scale);
                 }
             }
+
+            if (ImGui::CollapsingHeader("Physics", ImGuiTreeNodeFlags_DefaultOpen)) {
+                auto rigidBody = entity->getRigidBody();
+                if (rigidBody) {
+                    bool isStatic = rigidBody->isStatic();
+                    if (ImGui::Checkbox("Static", &isStatic)) {
+                        rigidBody->setStatic(isStatic);
+                    }
+
+                    bool usesGravity = rigidBody->isUsingGravity();
+                    if (ImGui::Checkbox("Use Gravity", &usesGravity)) {
+                        rigidBody->setUseGravity(usesGravity);
+                    }
+
+                    float mass = rigidBody->getMass();
+                    if (!isStatic && ImGui::DragFloat("Mass", &mass, 0.05f, 0.01f, 1000.0f)) {
+                        rigidBody->setMass(std::max(mass, 0.01f));
+                    }
+
+                    glm::vec3 velocity = rigidBody->getVelocity();
+                    if (ImGui::DragFloat3("Velocity", glm::value_ptr(velocity), 0.05f)) {
+                        rigidBody->setVelocity(velocity);
+                    }
+
+                    glm::vec3 acceleration = rigidBody->getAcceleration();
+                    if (ImGui::DragFloat3("Acceleration", glm::value_ptr(acceleration), 0.05f)) {
+                        rigidBody->setAcceleration(acceleration);
+                    }
+                } else {
+                    ImGui::TextUnformatted("No rigid body attached.");
+                }
+            }
+
+            if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen)) {
+                auto renderer = context ? context->renderer() : nullptr;
+                if (!renderer) {
+                    ImGui::TextUnformatted("Renderer unavailable.");
+                } else {
+                    auto &registry = renderer->resources();
+                    std::string currentMaterialName{entity->getMaterialId()};
+                    ImGui::Text("Material ID: %s", currentMaterialName.c_str());
+
+                    auto material = registry.getMaterial(currentMaterialName);
+                    if (!material) {
+                        ImGui::TextUnformatted("Material not found in registry.");
+                    } else {
+                        if (!material->getShaderName().empty()) {
+                            ImGui::Text("Shader: %s", material->getShaderName().c_str());
+                        }
+
+                        auto editableMaterial = material;
+                        auto ensureOverrideAndUpdate = [&](auto updater) {
+                            editableMaterial = ensureEntityMaterialOverride(entity, registry, editableMaterial);
+                            if (editableMaterial) {
+                                updater(*editableMaterial);
+                                currentMaterialName = std::string(entity->getMaterialId());
+                            }
+                        };
+
+                        glm::vec4 baseColor = editableMaterial->getBaseColor();
+                        if (ImGui::ColorEdit4("Base Color", glm::value_ptr(baseColor),
+                                              ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_Float)) {
+                            ensureOverrideAndUpdate([&](Render::Material &mat) { mat.setBaseColor(baseColor); });
+                        }
+
+                        float pointSize = editableMaterial->getPointSize();
+                        if (ImGui::DragFloat("Point Size", &pointSize, 0.1f, 0.0f, 2048.0f)) {
+                            ensureOverrideAndUpdate([&](Render::Material &mat) { mat.setPointSize(pointSize); });
+                        }
+
+                        const auto &floatParams = editableMaterial->getFloats();
+                        if (!floatParams.empty() && ImGui::TreeNode("Float Properties")) {
+                            for (const auto &entry : floatParams) {
+                                float value = entry.second;
+                                ImGui::PushID(entry.first.c_str());
+                                if (ImGui::DragFloat("##value", &value, 0.01f)) {
+                                    ensureOverrideAndUpdate([&](Render::Material &mat) { mat.setFloat(entry.first, value); });
+                                }
+                                ImGui::SameLine();
+                                ImGui::TextUnformatted(entry.first.c_str());
+                                ImGui::PopID();
+                            }
+                            ImGui::TreePop();
+                        }
+
+                        const auto &vec3Params = editableMaterial->getVec3s();
+                        if (!vec3Params.empty() && ImGui::TreeNode("Vec3 Properties")) {
+                            for (const auto &entry : vec3Params) {
+                                glm::vec3 value = entry.second;
+                                ImGui::PushID(entry.first.c_str());
+                                if (ImGui::DragFloat3("##value", glm::value_ptr(value), 0.01f)) {
+                                    ensureOverrideAndUpdate([&](Render::Material &mat) { mat.setVec3(entry.first, value); });
+                                }
+                                ImGui::SameLine();
+                                ImGui::TextUnformatted(entry.first.c_str());
+                                ImGui::PopID();
+                            }
+                            ImGui::TreePop();
+                        }
+
+                        const auto &vec4Params = editableMaterial->getVec4s();
+                        if (!vec4Params.empty() && ImGui::TreeNode("Vec4 Properties")) {
+                            for (const auto &entry : vec4Params) {
+                                glm::vec4 value = entry.second;
+                                ImGui::PushID(entry.first.c_str());
+                                if (ImGui::DragFloat4("##value", glm::value_ptr(value), 0.01f)) {
+                                    ensureOverrideAndUpdate([&](Render::Material &mat) { mat.setVec4(entry.first, value); });
+                                }
+                                ImGui::SameLine();
+                                ImGui::TextUnformatted(entry.first.c_str());
+                                ImGui::PopID();
+                            }
+                            ImGui::TreePop();
+                        }
+                    }
+                }
+            }
+
             ImGui::End();
+        }
+
+        std::shared_ptr<Scene::IEntity> EntityInspector::resolveSelectedEntity() const {
+            if (!context) {
+                return nullptr;
+            }
+
+            auto selected = context->getSelectedEntity();
+            if (!selected.has_value()) {
+                return nullptr;
+            }
+
+            auto world = context->worldSystem();
+            if (!world) {
+                return nullptr;
+            }
+
+            auto view = world->view();
+            auto it = std::find_if(view.bodies.begin(), view.bodies.end(),
+                                   [id = selected.value()](const std::shared_ptr<Scene::IEntity> &candidate) {
+                                       return candidate && candidate->getID() == id;
+                                   });
+            return it != view.bodies.end() ? *it : nullptr;
+        }
+
+        std::string EntityInspector::makeEntityMaterialPrefix(std::uint64_t entityId) {
+            std::ostringstream prefix;
+            prefix << "entity_" << entityId << "_";
+            return prefix.str();
+        }
+
+        std::string EntityInspector::makeEntityMaterialName(std::uint64_t entityId, std::string_view baseName) {
+            auto prefix = makeEntityMaterialPrefix(entityId);
+            std::string result = prefix;
+            result.append(baseName.data(), baseName.size());
+            return result;
+        }
+
+        bool EntityInspector::isEntityMaterialOverride(std::uint64_t entityId, std::string_view materialName) {
+            auto prefix = makeEntityMaterialPrefix(entityId);
+            return materialName.size() > prefix.size() && materialName.find(prefix) == 0;
+        }
+
+        std::shared_ptr<Render::Material>
+        EntityInspector::ensureEntityMaterialOverride(const std::shared_ptr<Scene::IEntity> &entity,
+                                                      Render::ResourceRegistry &registry,
+                                                      std::shared_ptr<Render::Material> currentMaterial) const {
+            if (!entity) {
+                return nullptr;
+            }
+
+            std::string currentMaterialName{entity->getMaterialId()};
+            if (isEntityMaterialOverride(entity->getID(), currentMaterialName)) {
+                if (currentMaterial) {
+                    return currentMaterial;
+                }
+                return registry.getMaterial(currentMaterialName);
+            }
+
+            if (!currentMaterial) {
+                currentMaterial = registry.getMaterial(currentMaterialName);
+            }
+
+            if (!currentMaterial) {
+                return nullptr;
+            }
+
+            auto overrideName = makeEntityMaterialName(entity->getID(), currentMaterialName);
+            auto overrideMaterial = registry.getMaterial(overrideName);
+            if (!overrideMaterial) {
+                overrideMaterial = currentMaterial->cloneWithName(overrideName);
+                registry.registerMaterial(overrideMaterial);
+            }
+
+            entity->setMaterialId(overrideName);
+            return overrideMaterial;
         }
 
         std::string_view EntityInspector::GetName() const { return name; }

--- a/app/modules/entity-inspector/Public/EntityInspector.h
+++ b/app/modules/entity-inspector/Public/EntityInspector.h
@@ -12,6 +12,13 @@
 #include <WorldSystem.h>
 
 namespace Arche {
+    namespace Render {
+        class Material;
+        class ResourceRegistry;
+    }
+}
+
+namespace Arche {
     namespace GUI {
 
         class EntityInspector : public IPanel {
@@ -25,6 +32,15 @@ namespace Arche {
           private:
             std::string name;
             std::shared_ptr<EditorSession> context;
+
+            std::shared_ptr<Scene::IEntity> resolveSelectedEntity() const;
+            static std::string makeEntityMaterialPrefix(std::uint64_t entityId);
+            static std::string makeEntityMaterialName(std::uint64_t entityId, std::string_view baseName);
+            static bool isEntityMaterialOverride(std::uint64_t entityId, std::string_view materialName);
+            std::shared_ptr<Render::Material>
+            ensureEntityMaterialOverride(const std::shared_ptr<Scene::IEntity> &entity,
+                                         Render::ResourceRegistry &registry,
+                                         std::shared_ptr<Render::Material> currentMaterial) const;
         };
 
     } // namespace GUI

--- a/engine/renderer/Public/IRenderable.h
+++ b/engine/renderer/Public/IRenderable.h
@@ -20,6 +20,8 @@ namespace Arche {
                 : m_meshName(std::move(meshName)), m_materialName(std::move(materialName)) {}
             std::string_view getMeshName() const override { return m_meshName; }
             std::string_view getMaterialName() const override { return m_materialName; }
+            void setMaterialName(std::string materialName) { m_materialName = std::move(materialName); }
+            void setMeshName(std::string meshName) { m_meshName = std::move(meshName); }
           private:
             std::string m_meshName;
             std::string m_materialName;

--- a/engine/renderer/Public/Material.h
+++ b/engine/renderer/Public/Material.h
@@ -18,6 +18,7 @@ namespace Arche {
             explicit Material(std::string name) : m_name(std::move(name)) {}
 
             const std::string& getName() const { return m_name; }
+            void setName(std::string name) { m_name = std::move(name); }
             // Common parameters you can extend as needed
             void setBaseColor(const glm::vec4& c) { m_baseColor = c; }
             const glm::vec4& getBaseColor() const { return m_baseColor; }
@@ -41,6 +42,12 @@ namespace Arche {
 
             void setVec4(std::string name, glm::vec4 v) { m_vec4s[std::move(name)] = v; }
             const std::unordered_map<std::string, glm::vec4>& getVec4s() const { return m_vec4s; }
+
+            std::shared_ptr<Material> cloneWithName(std::string newName) const {
+                auto copy = std::make_shared<Material>(*this);
+                copy->m_name = std::move(newName);
+                return copy;
+            }
 
           private:
             std::string m_name;

--- a/engine/scene/Public/CubeEntity.h
+++ b/engine/scene/Public/CubeEntity.h
@@ -39,6 +39,11 @@ namespace Arche {
 
             std::string_view getMeshId() override { return m_Renderable->getMeshName(); }
             std::string_view getMaterialId() override { return m_Renderable->getMaterialName(); }
+            void setMaterialId(std::string_view materialId) override {
+                if (m_Renderable) {
+                    m_Renderable->setMaterialName(std::string(materialId));
+                }
+            }
             std::string_view getShaderId() override { return "flat.color"; }
 
             // --- Identification ---

--- a/engine/scene/Public/IEntity.h
+++ b/engine/scene/Public/IEntity.h
@@ -35,6 +35,7 @@ namespace Arche {
 
             virtual std::string_view getMeshId() = 0;
             virtual std::string_view getMaterialId() = 0;
+            virtual void setMaterialId(std::string_view materialId) = 0;
             virtual std::string_view getShaderId() = 0;
             
             virtual std::string_view getName() const = 0;

--- a/engine/scene/Public/PlaneEntity.h
+++ b/engine/scene/Public/PlaneEntity.h
@@ -46,8 +46,9 @@ namespace Arche {
             std::shared_ptr<Physics::RigidBody> getRigidBody() override { return m_Rigidbody; }
             std::shared_ptr<Physics::ICollider> getCollider() override { return m_Collider; }
             
-            std::string_view getMeshId() override { return "plane.mesh"; }
-            std::string_view getMaterialId() override { return "plane.mat"; }
+            std::string_view getMeshId() override { return m_meshName; }
+            std::string_view getMaterialId() override { return m_materialName; }
+            void setMaterialId(std::string_view materialId) override { m_materialName = std::string(materialId); }
             std::string_view getShaderId() override { return "flat.color"; }
 
             // --- Identification ---
@@ -82,6 +83,8 @@ namespace Arche {
             std::shared_ptr<Physics::ICollider> m_Collider;
             std::shared_ptr<Render::IRenderable> m_Renderable;
             std::shared_ptr<Physics::RigidBody> m_Rigidbody;
+            std::string m_meshName{"plane.mesh"};
+            std::string m_materialName{"plane.mat"};
         };
     } // namespace Scene
 } // namespace Arche

--- a/engine/scene/Public/SphereEntity.h
+++ b/engine/scene/Public/SphereEntity.h
@@ -41,6 +41,11 @@ namespace Arche {
 
             std::string_view getMeshId() override { return m_renderable->getMeshName(); };
             std::string_view getMaterialId() override { return m_renderable->getMaterialName(); };
+            void setMaterialId(std::string_view materialId) override {
+                if (m_renderable) {
+                    m_renderable->setMaterialName(std::string(materialId));
+                }
+            }
             std::string_view getShaderId() override { return m_renderable->getMaterialName(); };
 
             std::string_view getName() const override { return m_name; };
@@ -64,7 +69,7 @@ namespace Arche {
 
             std::shared_ptr<Physics::RigidBody> m_rigidBody;
             std::shared_ptr<Physics::ICollider> m_collider;
-            std::shared_ptr<Render::IRenderable> m_renderable;
+            std::shared_ptr<Render::NamedRenderable> m_renderable;
         };
     } // namespace Scene
 } // namespace Arche


### PR DESCRIPTION
## Summary
- extend the entity inspector panel to edit transforms, physics properties, and material settings of the selected entity
- support per-entity material overrides by cloning registry materials on demand and exposing material setters on entities
- expose renderable and material helpers needed for overrides, including clone and setter utilities

## Testing
- `cmake -S . -B build` *(fails: repository references missing GLFW checkout and OpenGL dev packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a47776ac8325b214cd29e436b3e5)