### PR TITLE
Fix Vulkan path-tracing push-constants and add scene-change detection to reset accumulation

### DIFF
--- a/engine/renderer/Private/VulkanBackend.cpp
+++ b/engine/renderer/Private/VulkanBackend.cpp
@@ -2431,6 +2431,10 @@ namespace Arche {
 
             updatePtDescriptorSets();
 
+            PathTracePushConstants pc = pcData;
+            pc.imageW = m_offscreenExtent.width;
+            pc.imageH = m_offscreenExtent.height;
+
             // ── Record a one-shot compute command buffer ──────────────────────
             VkCommandBufferAllocateInfo cai{};
             cai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -2473,7 +2477,7 @@ namespace Arche {
                                     m_ptPipelineLayout, 0, 1, &m_ptDescSet, 0, nullptr);
             vkCmdPushConstants(cmd, m_ptPipelineLayout,
                                VK_SHADER_STAGE_COMPUTE_BIT, 0,
-                               sizeof(PathTracePushConstants), &pcData);
+                               sizeof(PathTracePushConstants), &pc);
 
             uint32_t gx = (m_offscreenExtent.width  + 15) / 16;
             uint32_t gy = (m_offscreenExtent.height + 15) / 16;

--- a/engine/renderer/Public/PathTracingPass.h
+++ b/engine/renderer/Public/PathTracingPass.h
@@ -4,6 +4,8 @@
 #include "Camera.h"
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_access.hpp>
+#include <cstdint>
+#include <cstring>
 
 #ifdef ARCHE_BACKEND_VULKAN
 #   include "VulkanBackend.h"
@@ -53,6 +55,18 @@ namespace Arche {
                 // ── Build sphere + material lists ─────────────────────────────
                 std::vector<GpuSphere>   spheres;
                 std::vector<GpuMaterial> materials;
+                std::size_t              sceneHash = 1469598103934665603ull; // FNV-1a seed
+
+                auto hashCombineU32 = [&](uint32_t v) {
+                    sceneHash ^= static_cast<std::size_t>(v);
+                    sceneHash *= 1099511628211ull;
+                };
+                auto hashCombineF32 = [&](float v) {
+                    static_assert(sizeof(float) == sizeof(uint32_t));
+                    uint32_t bits = 0;
+                    std::memcpy(&bits, &v, sizeof(bits));
+                    hashCombineU32(bits);
+                };
 
                 for (const auto &obj : view.opaqueObjects) {
                     if (obj.meshId != "uv_sphere.mesh") continue;
@@ -89,6 +103,17 @@ namespace Arche {
                     s.matIdx = static_cast<int>(materials.size());
                     spheres.push_back(s);
                     materials.push_back(mat);
+
+                    // Track scene content changes (transform/material edits, etc.)
+                    hashCombineF32(centre.x);
+                    hashCombineF32(centre.y);
+                    hashCombineF32(centre.z);
+                    hashCombineF32(radius);
+                    hashCombineF32(mat.albedo.x);
+                    hashCombineF32(mat.albedo.y);
+                    hashCombineF32(mat.albedo.z);
+                    hashCombineF32(mat.fuzzOrIOR);
+                    hashCombineU32(static_cast<uint32_t>(mat.type));
                 }
 
                 if (spheres.empty()) return;
@@ -103,6 +128,7 @@ namespace Arche {
                 if (m_prevSamplesPerFrame!= pts.samplesPerFrame)       reset = true;
                 if (m_prevAperture       != pts.aperture)              reset = true;
                 if (m_prevFocusDist      != pts.focusDistance)         reset = true;
+                if (m_prevSceneHash      != sceneHash)                 reset = true;
 
                 // Camera change detection
                 glm::mat4 vmat = view.viewMatrix;
@@ -116,6 +142,7 @@ namespace Arche {
                     m_prevSamplesPerFrame = pts.samplesPerFrame;
                     m_prevAperture        = pts.aperture;
                     m_prevFocusDist       = pts.focusDistance;
+                    m_prevSceneHash       = sceneHash;
                 }
 
                 // ── Build camera push constants ───────────────────────────────
@@ -192,6 +219,7 @@ namespace Arche {
             int       m_prevSamplesPerFrame{0};
             float     m_prevAperture{-1.0f};
             float     m_prevFocusDist{-1.0f};
+            std::size_t m_prevSceneHash{0};
         };
 
     } // namespace Render


### PR DESCRIPTION
### Motivation
- Ensure the Vulkan path-tracer receives correct image dimensions in its push-constants so the compute shader's bounds checks behave correctly and per-pixel dispatch is valid.  
- Make progressive accumulation robust to scene edits (new entities, transform changes, or material parameter edits) so the renderer resets accumulation when the underlying scene changes.

### Description
- Populate `PathTracePushConstants.imageW` and `imageH` before calling `vkCmdPushConstants` by copying `pcData` into a local `pc` and setting the offscreen extent in `engine/renderer/Private/VulkanBackend.cpp` so the shader receives correct dimensions.  
- Add an FNV-1a-style scene fingerprint in `engine/renderer/Public/PathTracingPass.h` that hashes sphere transform/radius and resolved `GpuMaterial` parameters (albedo, fuzz/IOR, type) to detect semantic scene changes.  
- Compare the computed scene hash to `m_prevSceneHash` and reset progressive accumulation state (`m_accumSamples`, `m_frameIndex`, and previous-state fields) when the hash changes.  
- Add small helpers and includes (`<cstdint>`, `<cstring>`) used for hashing and combining float/int bits into the scene hash.

### Testing
- Ran CMake configure with `cmake -S . -B build` to validate basic project configuration and discovered the environment lacks the vendored `tools/GLFW` CMakeLists and OpenGL development libraries, so a full build and runtime validation could not complete (configuration failed).  
- No automated unit/integration tests were executed in this environment due to the incomplete build configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0250c933c8325b6857aa80d244e48)